### PR TITLE
Added sys_project to configuration so that search functionality works on RHD

### DIFF
--- a/rivers/jbossdeveloper_vimeo_drupal.json
+++ b/rivers/jbossdeveloper_vimeo_drupal.json
@@ -30,6 +30,7 @@
       "sys_tags"                 : { "remote_field" : "prep_resource_tags" },
       "sys_title"                : { "remote_field" : "title" },
       "sys_type"                 : { "remote_field" : "prep_sys_type" },
+      "sys_project"                 : { "remote_field" : "prep_project" },
       "sys_updated"              : { "remote_field" : "prep_sys_updated" },
       "sys_url_view"             : { "remote_field" : "prep_sys_url_view" },
       "tags"                     : { "remote_field" : "prep_resource_tags" },
@@ -103,7 +104,24 @@
 
       "
       }
-    },
+    }, {
+        "name"     : "Projects mapper",
+        "class"    : "org.jboss.elasticsearch.tools.content.ESLookupValuePreprocessor",
+        "settings" : {
+          "index_name"       : "sys_projects",
+          "index_type"       : "project",
+          "source_field"     : "field_video_target_product",
+          "idx_search_field" : "jbossdeveloper_website_code",
+          "result_mapping"   : [{
+            "idx_result_field" : "code",
+            "target_field"     : "prep_project"
+          },{
+            "idx_result_field" : "name",
+            "target_field"     : "prep_project_name"
+          }
+          ]
+        }
+      },
       {
         "name"     : "Updated filler",
         "class"    : "org.jboss.elasticsearch.tools.content.AddCurrentTimestampPreprocessor",

--- a/rivers/jbossdeveloper_youtube_drupal.json
+++ b/rivers/jbossdeveloper_youtube_drupal.json
@@ -30,6 +30,7 @@
       "sys_tags"                 : { "remote_field" : "prep_resource_tags" },
       "sys_title"                : { "remote_field" : "title" },
       "sys_type"                 : { "remote_field" : "prep_sys_type" },
+      "sys_project"                 : { "remote_field" : "prep_project" },
       "sys_updated"              : { "remote_field" : "prep_sys_updated" },
       "sys_url_view"             : { "remote_field" : "prep_sys_url_view" },
       "tags"                     : { "remote_field" : "prep_resource_tags" },
@@ -102,6 +103,24 @@
           }
 
           "
+        }
+      },
+    {
+        "name"     : "Projects mapper",
+        "class"    : "org.jboss.elasticsearch.tools.content.ESLookupValuePreprocessor",
+        "settings" : {
+          "index_name"       : "sys_projects",
+          "index_type"       : "project",
+          "source_field"     : "field_video_target_product",
+          "idx_search_field" : "jbossdeveloper_website_code",
+          "result_mapping"   : [{
+            "idx_result_field" : "code",
+            "target_field"     : "prep_project"
+          },{
+            "idx_result_field" : "name",
+            "target_field"     : "prep_project_name"
+          }
+          ]
         }
       },
       {


### PR DESCRIPTION
@unibrew - I added the sys_project mapping for videos only at this point. Outside of quickstarts, boms and archetypes, it doesn't look like we really use the sys_project field for anything else on RHD. I could definitely add them to the other rivers, but the video issue is causing the learn pages to not function correctly.

https://issues.jboss.org/browse/DEVELOPER-4215?filter=-1