### PR TITLE
DEVELOPER-5210 - Updated sys_url_view to point to event url instead of formulated url

### DIFF
--- a/rivers/jbossdeveloper_events_drupal.json
+++ b/rivers/jbossdeveloper_events_drupal.json
@@ -35,7 +35,7 @@
       "sys_type"                    : { "remote_field" : "prep_sys_type"},
       "sys_id"                      : { "remote_field" : "prep_id"},
       "sys_updated"                 : { "remote_field" : "prep_sys_updated" },
-      "sys_url_view"                : { "remote_field" : "prep_sys_url_view" },
+      "sys_url_view"                : { "remote_field" : "field_more_details" },
       "sys_tags"                    : { "remote_field" : "prep_data_tags"}
 
     },
@@ -49,8 +49,7 @@
           "prep_sys_content_provider": "jboss-developer",
           "prep_sys_content_type"    : "jbossdeveloper_event",
           "prep_sys_created"         : "{created}",
-          "prep_sys_type"            : "event",
-          "prep_sys_url_view"        : "https://developers.redhat.com/events/event#!id={nid}"
+          "prep_sys_type"            : "event"
 
         }
       },


### PR DESCRIPTION
@unibrew - I couldn't get the indexer to run on staging for some reason. Are any of the indexers actively running?

I'm wondering if strange results are returning because we are pointing to a legacy drupal build (seems unlikely, but would explain why we're getting incorrect results from DCP).  I can provide you with correct url for the apiKey (used to hide the production url) on Slack if need be.

